### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ yarn add a11y-vue-dialog
 ```
 
 ```js
-// portal vue is installed as dependency
+// portal vue is binstalled as dependency, and it's required
 import PortalVue from "portal-vue";
 Vue.use(PortalVue);
 
@@ -24,23 +24,97 @@ Vue.use(A11yVueDialog);
 
 ```html
 <a11y-vue-dialog :open="true">
-  <p>This slot content will be rendered wherever the <portal-target> with name 'destination'
+  <p>This slot content will be rendered wherever the <portal-target> with name 'a11y-vue-dialogs'
     is  located.</p>
 </a11y-vue-dialog>
 ```
 
 ```html
-<!-- in your app.vue -->
-<portal-target name="dialogs" multiple />
+<!-- in your app.vue, name can be costumized via portalTargetName prop locally or global -->
+<portal-target name="a11y-vue-dialogs" multiple />
 ```
+
+## Customization
+#### Custom global installation
+```js
+// GLOBAL
+import Portal from "portal-vue";
+import A11yVueDialog from "a11y-vue-dialog";
+
+Vue.use(Portal, {
+  portalName: "black-hole", //[1]
+  portalTargetName: "black-holes-meeting" //[2]
+});
+Vue.use(A11yVueDialog, {
+  componentName: "AppNameDialog", // [3] custom registered namee
+  // override default prop values on global registration
+  props: {
+    // ⚠️needs to match portal ⚠️
+    portalName: "black-hole", //[1]
+    portalTargetName: "my-dialogs-contaner" //[4]
+  }
+});
+```
+
+```html
+<!-- [3] -->
+<app-name-dialog :open="true">
+  <p>This slot content will be rendered wherever the <black-holes-meeting> with name 'my-dialogs-container'
+    is  located.</p>
+</app-name-dialog>
+```
+
+```html
+<!--  [2, 4] -->
+<black-holes-meeting name="my-dialogs-contaner" multiple />
+```
+#### Custom local installation
+
+```html
+<script>
+// assuming portal global default installation
+// note the named export!
+import { A11yVueDialog } from "a11y-vue-dialog";
+
+export default {
+  name: "your-component",
+  components: {
+    dialog: A11yVueDialog
+  },
+  data () => ({
+    open: false
+  })
+}
+</script>
+
+<template>
+  <dialog :open="open">
+    <p>This slot content will be rendered wherever the <portal-target> with name 'a11y-vue-dialogs'
+    is  located.</p>
+  </dialog>
+</template>
+
+```
+
 
 
 ## Why another modal/dialog plugin
 
-✅ Accessibility first — Focus trap + keybindings + plus aria-hidden
-✅ Fully controlled component
-✅ Pure vue, no wrapping.
-✅ Simplicity + size
+- ✅ Accessibility first — Focus trap + keyboard navigation + aria-attributes
+- ✅ Fully controlled component
+- ✅ Pure vue, no wrapping.
+- ✅ Simplicity + size
+- 🕸 Nested dialogs ([questionable pattern](https://github.com/edenspiekermann/a11y-dialog#nested-dialogs), not recommended, but possible because [it happens](https://cl.ly/be43f69393f7))
+- 🔜 _renderless version_
+
+## Why use portal-vue?
+Because accessibility is at the core of this plugin, and rendering the dialog in the middle of your content cause aria-attributes to be misplaced and probably a couple of other issues (overflow trap, stacking context caused by transforms)).
+
+Portal-vue was choosen because it is actively maintained and the _de facto_ solution for portals in vue.js.
+
+#### But i have my own portal
+Althought technically possible, there will be no public instructions on how to do it. (hint: we use `<component :is="portalName" />` to allow custom `portal-vue` component registrations).
+If you're considering this case, you probably can figure it out yourself by looking at the source code. But not guarantees of compatibility are give. If this becomes a common request, it's not difficult for me to decouple `a11y-vue-dialog` from `portal-vue`, but after that i'm not sure if I could still probably call it _accessible_. I'll promise to think about it for future versions, but not planned.
 
 
 ## Inspiration && thanks

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Install
 
-add your package
+add the package
 ```
 npm i a11y-vue-dialog
 
@@ -22,14 +22,14 @@ Vue.use(A11yVueDialog);
 
 ## Usage
 
-```vue
+```html
 <a11y-vue-dialog :open="true">
   <p>This slot content will be rendered wherever the <portal-target> with name 'destination'
     is  located.</p>
 </a11y-vue-dialog>
 ```
 
-```vue
+```html
 <!-- in your app.vue -->
 <portal-target name="dialogs" multiple />
 ```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,15 @@
   "description": "An accessible dialog component made for Vue",
   "repository": "git@github.com:renatodeleao/a11y-vue-dialog.git",
   "author": "Renato de Leão <renatodeleao@gmail.com>",
-  "keywords": ["accessibility", "a11y", "dialog", "modal", "popup", "portal", "vue"],
+  "keywords": [
+    "accessibility",
+    "a11y",
+    "dialog",
+    "modal",
+    "popup",
+    "portal",
+    "vue"
+  ],
   "license": "MIT",
   "main": "src/index.js",
   "module": "dist/a11y-vue-dialog.esm.js",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "An accessible dialog component made for Vue",
   "repository": "git@github.com:renatodeleao/a11y-vue-dialog.git",
   "author": "Renato de Leão <renatodeleao@gmail.com>",
+  "keywords": ["accessibility", "a11y", "dialog", "modal", "popup", "portal", "vue"],
   "license": "MIT",
   "main": "src/index.js",
   "module": "dist/a11y-vue-dialog.esm.js",

--- a/src/A11yVueDialog.vue
+++ b/src/A11yVueDialog.vue
@@ -50,9 +50,7 @@
 </template>
 
 <script>
-import Portal from "portal-vue";
 import Skeleton from "./components/Skeleton.vue";
-
 
 const FOCUSABLE_ELEMENTS = [
   'a[href]:not([tabindex^="-"]):not([inert])',
@@ -79,8 +77,7 @@ const getInitialState = () => ({
 export default {
   name: "dialog-base",
   components: {
-    Skeleton,
-    Portal
+    Skeleton
   },
   props: {
     open: {

--- a/src/A11yVueDialog.vue
+++ b/src/A11yVueDialog.vue
@@ -129,7 +129,11 @@ export default {
       handler: function(open) {
         if( open ) {
           this.handleBackgroundScrolling(true);
-          this.openDuties();
+
+          this.$nextTick(() => {
+            this.$emit('open', this);
+            this.openDuties();
+          })
         } else {
           this.handleBackgroundScrolling(false);
           this.resetData();
@@ -148,7 +152,7 @@ export default {
         this.getFocusableChildren();
         this.observeContents(true);
         this.ariaHandler(true)
-      })
+       });
     },
 
     dismiss() {

--- a/src/A11yVueDialog.vue
+++ b/src/A11yVueDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <portal to="dialogs" v-if="open">
+  <component :is="portalName" :to="portalTargetName" v-if="open">
     <div
       :id="`dialog-${_uid}`"
       :class="classObj"
@@ -46,7 +46,7 @@
         </footer>
       </skeleton>
     </div>
-  </portal>
+  </component>
 </template>
 
 <script>
@@ -80,6 +80,14 @@ export default {
     Skeleton
   },
   props: {
+    portalName: {
+      type: String,
+      default: "portal"
+    },
+    portalTargetName: {
+      type: [String, null],
+      default: "a11y-vue-dialogs"
+    },
     open: {
       type: Boolean,
       default: false

--- a/src/A11yVueDialog.vue
+++ b/src/A11yVueDialog.vue
@@ -75,7 +75,7 @@ const getInitialState = () => ({
 })
 
 export default {
-  name: "dialog-base",
+  name: "a11y-vue-dialog",
   components: {
     Skeleton
   },

--- a/src/A11yVueDialog.vue
+++ b/src/A11yVueDialog.vue
@@ -282,7 +282,7 @@ export default {
 
       if (contentRoot) {
         contentRootSiblings.push(document.querySelector(contentRoot))
-      } else {
+      } else if (this.portalTarget) {
         contentRootSiblings = this.getSiblings(this.portalTarget);
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -32,4 +32,5 @@ var Plugin = {
 	}
 }
 
+export { A11yVueDialog };
 export default Plugin;

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,10 @@ import A11yVueDialog from "./A11yVueDialog.vue";
 // optional stylesheet
 import "./styles/a11y-vue-dialog.scss";
 
-var COMPONENT_NAME = "A11yVueDialog"
+const DEFAULTS = {
+  componentName: "a11y-vue-dialog",
+}
+
 var Plugin = {
   install (Vue, options = {}) {
     /**
@@ -13,13 +16,19 @@ var Plugin = {
 		}
 
 		this.installed = true;
-		this.componentName = options.componentName || COMPONENT_NAME;
+		this.componentName = options.componentName || DEFAULTS.componentName;
 
-		var testing = () => {
-			return COMPONENT_NAME;
-		}
-		var ref = testing;
-		Vue.component(this.componentName, A11yVueDialog);
+    // is there a better way of doing this
+    // (extend default prop value on component registration)*
+    if( options.props) {
+      Object.keys(A11yVueDialog.props).map(propName => {
+        if(options.props[propName]) {
+          A11yVueDialog.props[propName]['default'] = options.props[propName];
+        }
+      });
+    }
+
+	  Vue.component(this.componentName, A11yVueDialog)
 	}
 }
 


### PR DESCRIPTION
- This actually fixes v0.1.0 which doesn't work. (sry for the noob npm publish 🤦‍♂️ ) I learn about `yarn link` so it won't happen again (pinky promise)
- minor bugfixes
- [breaking change]: new default namespaced `portalTargetName` from `dialogs` to `a11y-vue-dialogs` to avoid conflicts with other existent plugins
- Allow custom portalName and portalTargetName instead of hardcoding, allowing for more flexible installations of `portal-vue`