### PR TITLE
Uuuuupdates

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,38 @@ props: {
   },
 }
 
+#### Slots
+
+*slot: default*
+Use to render the body of the dialog
+```html
+<a11y-vue-dialog>this goes to the default slots</a11-vue-dialog>
+```
+
+*slot: a11y-vue-dialog-title*
+to add text(and html) to the title that lives in dialog header
+```html
+<a11y-vue-dialog>
+  <template slot="a11y-vue-dialog-title">Yei an <strong>html</strong>title</template>
+</a11-vue-dialog>
+
+*slot: a11y-vue-dialog-close*
+```html
+<a11y-vue-dialog>
+  <button slot="a11y-vue-dialog-close" class="my-custom-button"></button>
+</a11-vue-dialog>
+```
+
+*slot: a11y-vue-dialog-footer*
+```html
+<a11y-vue-dialog>
+  <template slot="a11y-vue-dialog-footer">
+    <button class="my-custom-button" @click="$emit('close')">Cancel</button>
+    <button class="my-custom-button" @click="someAction">Submit</button>
+  </template>
+</a11-vue-dialog>
+```
+
 
 ## Why another modal/dialog plugin
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,66 @@ export default {
 
 ```
 
+#### Props
+
+```js
+props: {
+  /**
+   * @desc must match to globally/locall registered portal-vue portalName
+   */
+  portalName: {
+    type: String,
+    default: "portal"
+  },
+  /**
+   * @desc must mach an existent portal-vue portal-target
+   */
+  portalTargetName: {
+    type: [String, null],
+    default: "a11y-vue-dialogs"
+  },
+  /**
+   * @desc control's dialog visibility
+   */
+  open: {
+    type: Boolean,
+    default: false
+  },
+  /**
+   * @desc add overflow hidden to app root
+   */
+  preventBackgroundScrolling: {
+    type: Boolean,
+    default: true
+  },
+  /**
+   * @desc accessibilty attribute: possible usage as modal
+   * @url https://github.com/edenspiekermann/a11y-dialog#usage-as-a-modal
+   */
+  role: {
+    type: String,
+    default: "dialog",
+    validator: (v) => ["dialog", "alertdialog"].indexOf(v) > -1
+  },
+  /**
+   * @desc accessibilty attribute: hide content from screen readers
+   * when dialog is open. if null, defaults to siblings of portal-target element
+   */
+  contentRoot: {
+    type: [String, null],
+    default: null
+  },
+  /**
+   * @desc classname that will prefix all HTML element
+   * @note opininated, BEM selectors will be created for each element.
+   * if using with sass, you should also match $avd-classname variable
+   * before import styles. More on styling
+   */
+  baseClassname: {
+    type: [String],
+    default: "c-dialog"
+  },
+}
 
 
 ## Why another modal/dialog plugin

--- a/src/A11yVueDialog.vue
+++ b/src/A11yVueDialog.vue
@@ -3,7 +3,6 @@
     <div
       :id="`dialog-${_uid}`"
       :class="classObj"
-      :content-root="contentRoot"
       ref="backdrop"
       @click="handleBackdropClick"
     >
@@ -141,8 +140,8 @@ export default {
     baseClassname: {
       type: [String],
       default: "c-dialog",
-      validator: (val) => (val !== ""),
-    },
+      validator: (val) => val !== ""
+    }
   },
   data: () => getInitialState(),
   computed: {
@@ -318,14 +317,18 @@ export default {
       const contentRoot = this.contentRoot;
       let contentRootSiblings = [];
 
+      // check if content-root prop is not null, in affirmative case
+      // we just want to target it, nothing else
       if (contentRoot) {
         contentRootSiblings.push(document.querySelector(contentRoot))
       } else if (this.portalTarget) {
+      // if not, we default to find the same level elements (siblings)
+      // and apply aria-attributes to them
         contentRootSiblings = this.getSiblings(this.portalTarget);
       }
 
       if( bool ){
-        contentRootSiblings.map(s => s.setAttribute('aria-hidden', 'true'))
+        contentRootSiblings.map( s => s.setAttribute('aria-hidden', 'true'))
       } else {
         contentRootSiblings.map( s => s.removeAttribute('aria-hidden'))
       }

--- a/src/A11yVueDialog.vue
+++ b/src/A11yVueDialog.vue
@@ -40,14 +40,10 @@
           <slot />
         </section>
 
-<<<<<<< HEAD
-        <footer slot="skeleton-feet" :class="`${baseClass}__footer`" v-if="$slots['dialog-footer']">
-=======
         <footer slot="skeleton-feet"
           :class="`${baseClassname}__footer`"
           v-if="$slots['a11y-vue-dialog-footer']"
         >
->>>>>>> f256d32... fixup! namespace slots a11y-vue-dialog
           <slot name="a11y-vue-dialog-footer" />
         </footer>
       </skeleton>

--- a/src/A11yVueDialog.vue
+++ b/src/A11yVueDialog.vue
@@ -80,43 +80,62 @@ export default {
     Skeleton
   },
   props: {
+      /**
+     * @desc must match to globally/locall registered portal-vue portalName
+     */
     portalName: {
       type: String,
       default: "portal"
     },
+    /**
+     * @desc must mach an existent portal-vue portal-target
+     */
     portalTargetName: {
       type: [String, null],
       default: "a11y-vue-dialogs"
     },
+    /**
+     * @desc control's dialog visibility
+     */
     open: {
       type: Boolean,
       default: false
     },
+    /**
+     * @desc add overflow hidden to app root
+     */
     preventBackgroundScrolling: {
       type: Boolean,
       default: true
     },
     /**
-     * possible usage as modal
-     * https://github.com/edenspiekermann/a11y-dialog#usage-as-a-modal
+     * @desc accessibilty attribute: possible usage as modal
+     * @url https://github.com/edenspiekermann/a11y-dialog#usage-as-a-modal
      */
     role: {
       type: String,
       default: "dialog",
       validator: (v) => ["dialog", "alertdialog"].indexOf(v) > -1
     },
+    /**
+     * @desc accessibilty attribute: hide content from screen readers
+     * when dialog is open. if null, defaults to siblings of portal-target element
+     */
     contentRoot: {
       type: [String, null],
       default: null
     },
-    theme: {
-      type: [String, null],
-      default: null
+    /**
+     * @desc classname that will prefix all HTML element
+     * @note opininated, BEM selectors will be created for each element.
+     * if using with sass, you should also match $avd-classname variable
+     * before import styles. More on styling
+     */
+    baseClassname: {
+      type: [String],
+      default: "c-dialog",
+      validator: (val) => (val !== ""),
     },
-    size: {
-      type: [String, null],
-      default: null
-    }
   },
   data: () => getInitialState(),
   computed: {

--- a/src/A11yVueDialog.vue
+++ b/src/A11yVueDialog.vue
@@ -7,7 +7,7 @@
       @click="handleBackdropClick"
     >
       <skeleton
-        :class="`${baseClass}__inner`"
+        :class="`${baseClassname}__inner`"
         :role="role"
         aria-labelledby="dialog-title"
         aria-describedby="dialog-desc"
@@ -16,13 +16,13 @@
         @keydown.tab="trapFocus"
         ref="dialog"
       >
-        <header :class="`${baseClass}__header`" slot="skeleton-head">
-          <h1 id="dialog-title" :class="`${baseClass}__title`">
+        <header :class="`${baseClassname}__header`" slot="skeleton-head">
+          <h1 id="dialog-title" :class="`${baseClassname}__title`">
             <slot name="a11y-vue-dialog-title">Dialog Title</slot>
           </h1>
           <div
             ref="close"
-            :class="`${baseClass}__close`"
+            :class="`${baseClassname}__close`"
             tabindex="0"
             type="button"
             aria-label="Close this dialog window"
@@ -36,7 +36,7 @@
           </div>
         </header>
 
-        <section :class="`${baseClass}__body`" id="dialog-desc">
+        <section :class="`${baseClassname}__body`" id="dialog-desc">
           <slot />
         </section>
 
@@ -145,14 +145,10 @@ export default {
   },
   data: () => getInitialState(),
   computed: {
-    baseClass(){
-      return "c-dialog"
-    },
     classObj(){
       return {
-        [this.baseClass]: true,
-        [`${this.baseClass}--${this.theme}`]: this.theme,
-        [`${this.baseClass}--${this.size}`]: this.size
+        [this.baseClassname]: true,
+        [`${this.baseClassname}--is-open`]: this.open,
       }
     }
   },
@@ -238,7 +234,7 @@ export default {
     // All credits to Hugo Giraudel for this
     // https://github.com/edenspiekermann/a11y-dialog/blob/master/a11y-dialog.js
     //
-    // Copied and adptade to this instance
+    // adapted to this instance
     // ----------------
 
     /**

--- a/src/A11yVueDialog.vue
+++ b/src/A11yVueDialog.vue
@@ -19,7 +19,7 @@
       >
         <header :class="`${baseClass}__header`" slot="skeleton-head">
           <h1 id="dialog-title" :class="`${baseClass}__title`">
-            <slot name="title">Dialog Title</slot>
+            <slot name="a11y-vue-dialog-title">Dialog Title</slot>
           </h1>
           <div
             ref="close"
@@ -31,7 +31,7 @@
             @keydown.enter.prevent="dismiss"
             @keydown.space="dismiss"
           >
-            <slot name="close-button">
+            <slot name="a11y-vue-dialog-close">
               &times;
             </slot>
           </div>
@@ -41,8 +41,15 @@
           <slot />
         </section>
 
+<<<<<<< HEAD
         <footer slot="skeleton-feet" :class="`${baseClass}__footer`" v-if="$slots['dialog-footer']">
-          <slot name="dialog-footer" />
+=======
+        <footer slot="skeleton-feet"
+          :class="`${baseClassname}__footer`"
+          v-if="$slots['a11y-vue-dialog-footer']"
+        >
+>>>>>>> f256d32... fixup! namespace slots a11y-vue-dialog
+          <slot name="a11y-vue-dialog-footer" />
         </footer>
       </skeleton>
     </div>


### PR DESCRIPTION
- 🎉 more docs, more fun
- ☢️ breaking-change: namespaced slots to `a11y-vue-dialog-{slotName}` for consitency
- ☢️ deprecate theme and size props, this were opinionated props to construct computed classnames, but they come before this component was decoupled. The same thing can be achived via `:class` attribute binding on parent.

There's going to be a lot of breaking changes till v1.0.0, sry for the mess!