### PR TITLE
Feat: focus trap next

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ## Why another modal/dialog plugin
 
-- ✅ Accessibility first — Focus trap + keyboard navigation + aria-attributes
+- ✅ Accessibility first — Focus trap<sup>[1]</sup> + keyboard navigation + aria-attributes
 - ✅ Fully controlled component
 - ✅ Pure vue, no wrapping.
 - ✅ Simplicity + size
-- 🕸 Nested dialogs ([questionable pattern](https://github.com/edenspiekermann/a11y-dialog#nested-dialogs), not recommended, but possible because [it happens](https://cl.ly/be43f69393f7))
+- 🕸 Nested dialogs ([questionable pattern](https://github.com/edenspiekermann/a11y-dialog#nested-dialogs), not recommended, but possible because [it happens](https://cl.ly/be43f69393f7)) and it's actually in WAI-ARIA [examples](https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html) so...
 - 🚧 _renderless version_
 
 Detailed documentation and additional info is available [at documentation site](https://renatodeleao.github.io/a11y-vue-dialog/)
@@ -146,6 +146,23 @@ export default {
 A playground is used to test the component locally. It uses [`vue/cli` instant prototyping feature](https://cli.vuejs.org/guide/prototyping.html), so the downside is that you have to install it globally. 
 
 - Then, just run `yarn play` 
+
+## Acknowledgements
+1. Since `v0.5.0` focus trap is powered by the awesome [`focus-trap`](https://github.com/focus-trap/focus-trap) — go and give them some ✨
+
+## Colophon
+Thanks to all this packages for inspiration and guidance.
+
+#### Dependencies
+
+1. Since `v0.5.0` focus trap is powered by the awesome [`focus-trap`](https://github.com/focus-trap/focus-trap) — go and give them some ✨
+1. [portal-vue](https://github.com/LinusBorg/portal-vue/) from @LinusBorg wich makes escape overflow traps like breeze
+
+#### Acknowledgements
+- a11y-dialog (vanilla) from @HugoGiraudel to lead the path that ended here
+- vue-a11y-dialog (wrapper around ^) from @morkro for the motivation to build a pure vue alternative to it.
+- vue-js-dialog a fully fledge massive dialog
+
 
 ## License
 MIT © Renato de Leão

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -3,12 +3,15 @@ title: Introduction
 ---
 ## Why another modal/dialog plugin
 
-- ✅ Accessibility first — Focus trap + keyboard navigation + aria-attributes
+- ✅ Accessibility first — Focus trap<sup>[1]</sup> keyboard navigation + aria-attributes
 - ✅ Fully controlled component
 - ✅ Pure vue, no wrapping.
 - ✅ Simplicity + size
-- 🕸 Nested dialogs ([questionable pattern](https://github.com/edenspiekermann/a11y-dialog#nested-dialogs), not recommended, but possible because [it happens](https://cl.ly/be43f69393f7))
+- 🕸 Nested dialogs ([questionable pattern](https://github.com/edenspiekermann/a11y-dialog#nested-dialogs), not recommended, but possible because [it happens](https://cl.ly/be43f69393f7)) and it's actually in WAI-ARIA [examples](https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html) so...
 - 🚧 _renderless version_
+
+#### Footnotes
+1. Since `v0.5.0` focus trap is powered by the awesome [`focus-trap`](https://github.com/focus-trap/focus-trap) — go and give them some ✨
 
 
 ## Why Not ...?

--- a/docs/guide/props.md
+++ b/docs/guide/props.md
@@ -4,6 +4,7 @@
 props: {
   /**
    * @desc must match to globally/locall registered portal-vue portalName
+   * NOT PRESENT IN RENDERLESS VERSION
    */
   portalName: {
     type: String,
@@ -11,6 +12,7 @@ props: {
   },
   /**
    * @desc must mach an existent portal-vue portal-target
+   * NOT PRESENT IN RENDERLESS VERSION
    */
   portalTargetName: {
     type: [String, null],
@@ -52,9 +54,23 @@ props: {
    * @note opininated, BEM selectors will be created for each element.
    * if using with sass, you should also match $avd-classname variable
    * before import styles. More on styling
+   * NOT PRESENT IN RENDERLESS VERSION
    */
   baseClassname: {
     type: [String],
     default: "c-dialog"
   },
+  /**
+   * @desc focus-trap package configuration object
+   * @note We use focus-trap pacakge to handle our trapping needs. It's awesome,
+   * give them an high-five. You can use this to provide any options
+   * that the library would accept. Note that we do not use active/deactive
+   * since it will be active if dialog is shown and deactivated otherwise
+   * ONLY PRESENT IN RENDERLESS VERSION
+   * @see {@link https://github.com/focus-trap/focus-trap#usage} 
+   */
+  focusTrapCreateOptions: {
+    type: Object,
+    default: () => ({})
+  }
 }

--- a/docs/guide/thanks.md
+++ b/docs/guide/thanks.md
@@ -1,7 +1,8 @@
 # Inspiration && thanks
-Thanks to all this packages for inspiration and guidance.
+Thanks to all these packages authors and contributors for inspiration and guidance.
 
 - [portal-vue](https://github.com/LinusBorg/portal-vue) from [@LinusBorg](https://github.com/LinusBorg) wich makes escape overflow traps like breeze
 - [a11y-dialog (vanilla)](http://edenspiekermann.github.io/a11y-dialog/) from [@HugoGiraudel](https://github.com/HugoGiraudel) to lead the path that ended here
 - [vue-a11y-dialog (wrapper around ^)](https://github.com/morkro/vue-a11y-dialog) from [@morkro](https://github.com/morkro) for the motivation to build a pure vue alternative to it.
 - [vue-js-dialog](https://github.com/euvl/vue-js-modal) a fully fledge massive dialog
+- [`focus-trap`](https://github.com/focus-trap/focus-trap) — managing our dialog focus needs

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "src"
   ],
   "dependencies": {
+    "focus-trap": "^6.1.1",
     "portal-vue": "^1.5.1"
   },
   "resolutions": {

--- a/playground/DialogExample.vue
+++ b/playground/DialogExample.vue
@@ -19,6 +19,7 @@
 
             <section>
               <h2>Content</h2>
+              <input type="text" autofocus placeholder="test" />
               <button @click="innerTest = !innerTest">Show this</button>
               <div v-if="innerTest">
                 with dynamic <a href="#asda">focusable elements</a> to check if the focus trap is still working

--- a/src/__tests__/A11yVueDialogRenderless.spec.js
+++ b/src/__tests__/A11yVueDialogRenderless.spec.js
@@ -280,62 +280,6 @@ describe("A11yVueDialogRenderless", () => {
   })
 
   describe('behaviour', () => {
-    describe('focus', () => {
-
-      it('should focus on first focusable child unless a rule stating otherwiser', async () => {
-        const _wrapper = mountWithOptions({
-          data: () => ({ isOpen: true })
-        })
-
-        // watch out for v-if
-        await _wrapper.vm.$nextTick()
-
-        const firstFocusableChildMock = _wrapper.find('[data-ref="close"]')
-        expect(firstFocusableChildMock.attributes('data-ref')).toBe(document.activeElement.getAttribute('data-ref'))
-      })
-
-      it('should set initial focus on the first element with autofocus attribute, if it exists', async () => {
-        const _wrapper = mountWithOptions({
-          propsData: {
-            showAutofocusEl: true
-          },
-          data: () => ({ isOpen: true })
-        })
-
-        // watch out for v-if
-        await _wrapper.vm.$nextTick()
-
-        const autofocusEl = _wrapper.find('[autofocus]')
-        expect(autofocusEl.attributes('id')).toBe(document.activeElement.id)
-      })
-
-      it('should set focus on the focusRef bound element, if it exists and is non-inert', async () => {
-        const _wrapper = mountWithOptions({
-          propsData: {
-            showFocusRef: true
-          },
-          data: () => ({ isOpen: true })
-        })
-
-        // watch out for v-if
-        await _wrapper.vm.$nextTick()
-
-        const focusRefEl = _wrapper.find('[data-ref="focus"]')
-        expect(focusRefEl.attributes('id')).toBe(document.activeElement.id)
-      })
-
-      
-      /**
-       * @todo good luck
-       */
-      // it('should run focus assignment again if current focus el is removed from the dom', () => {})
-
-      /**
-       * @todo
-       */
-      // it('should trap focus within dialog tab + shift + tab key', () => {})
-    })
-
     describe('scroll', () => {
       it('should prevent body scrolling if preventBackgroundScrolling is set to true on open', async () => {
         const _wrapper = mountWithOptions({ data: () => ({ isOpen: true }) })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5104,6 +5104,13 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+focus-trap@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.1.1.tgz#61881b58e56783a7ca7331c6969336b986313594"
+  integrity sha512-sTTf6esJ2iCdn8WpUEB4LfJl7tvjGLASV3JmXbi7q1N5Ajjyk+65qZdrmjOF01s+/1v81rTNYZrsTeGha5KKpg==
+  dependencies:
+    tabbable "^5.1.0"
+
 focus-visible@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-5.1.0.tgz#4b9d40143b865f53eafbd93ca66672b3bf9e7b6a"
@@ -10817,6 +10824,11 @@ symbol-tree@^3.2.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
+tabbable@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.1.0.tgz#b81115168d0a8359ba69003b6a99d05f8480a664"
+  integrity sha512-Y3nSukchqM5UchuZjhj/WyE79Qb4RM/Vx3x3oHO3UYKKpf70Hy3iVRxb61MzCavN74aZsKzvPl4KNG8tQUAjFQ==
 
 table@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
Closes #22 

Replaces internal focus trap management — read monstrous hackery — for a production-ready, drop-in solution by  the awesome [`focus-trap`](https://github.com/focus-trap/focus-trap) community.

Btw checkout [focus-trap-vue](https://github.com/posva/focus-trap-vue) from @posva, that's where i found `focus-trap` in the first place!

