### PR TITLE
refactor!: rename component and exports to simply a11y-dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm i a11y-vue-dialog
 
 # or
 
-yarn add a11y-vue-dialog 
+yarn add a11y-dialog 
 ```
 
 ## Usage
@@ -27,7 +27,7 @@ A renderless/headless component provides all the functionality required to build
 ```vue
 <!-- AppBaseDialog.vue -->
 <template>
-  <a11y-vue-dialog-renderless 
+  <a11y-dialog 
     v-bind="$attrs" 
     v-on="$listeners"
     v-slot:default="{ titleRef, closeRef }"
@@ -37,15 +37,15 @@ A renderless/headless component provides all the functionality required to build
     <button v-bind="closeRef.props" v-on="closeRef.listeners">
     ...
     <slot />
-  </a11y-vue-dialog>
+  </a11y-dialog>
 </template>
 
 <script>
-import { A11yVueDialogRenderless } from 'a11y-vue-dialog'
+import { A11yDialog } from 'a11y-dialog'
 
 export default {
   name: 'AppBaseDialog',
-  components: { A11yVueDialogRenderless },
+  components: { A11yDialog },
   props: {
     title: {
       type: String,
@@ -83,7 +83,7 @@ import Plugin from "a11y-vue-dialog";
 
 // if you want to register globally
 Vue.use(Plugin);
-// exposes a component name <a11y-vue-dialog> by default, but configurable
+// exposes a component name <a11y-dialog> by default, but configurable
 ```
 ### Teleporting outside of document flow
 This component should work with any `portal|teleport` solution. We don't ship one as a dependency because it's not a requirement from a wai-aria guidelines standpoint. That being said, I could not recommend enough the usage of one, to escape common rendering gotchas with dialogs — the overflow trap.
@@ -122,7 +122,7 @@ The default `scopedSlot` props help you bind the accessibility attributes and ev
 ```vue
 <!-- compose into you own markup, MyDialog.vue -->
 <template>
-  <a11y-vue-dialog-renderless 
+  <a11y-dialog 
     v-bind="$attrs"
     v-bind="$listeners"
     #default="{ closeFn, backdropRef, dialogRef, titleRef, closeRef, focusRef }"
@@ -158,15 +158,15 @@ The default `scopedSlot` props help you bind the accessibility attributes and ev
         </footer>
       </div>
     </div>
-  </a11y-vue-dialog-renderless>
+  </a11y-dialog>
 </template>
 
 <script>
-import { A11yVueDialogRenderless } from "a11y-vue-dialog";
+import { A11yDialog } from "a11y-vue-dialog";
 
 export default {
   name: 'AppDialog',
-  components: { A11yVueDialogRenderless },
+  components: { A11yDialog },
 }
 </script>
 ```
@@ -197,9 +197,9 @@ This demo uses [vue-simple-portal](https://github.com/LinusBorg/vue-simple-porta
 ```vue
 <template>
   <portal v-if="open">
-    <a11y-vue-dialog-renderless>
+    <a11y-dialog>
       <!-- your implementation like above -->
-    </a11y-vue-dialog-renderless>
+    </a11y-dialog>
   </portal>
 </template>
 
@@ -207,7 +207,7 @@ This demo uses [vue-simple-portal](https://github.com/LinusBorg/vue-simple-porta
 import { Portal } from '@linusborg/vue-simple-portal'
 
 export default {
-  components: { Portal, A11yVueDialogRenderless }
+  components: { Portal, A11yDialog }
 }
 </script>
 ```
@@ -228,13 +228,13 @@ But based on the info above, this also works fine:
           could also be applied to the component itself
     -->
     <transition name="fade" appear v-if="open">
-      <a11y-vue-dialog-renderless 
+      <a11y-dialog 
         v-bind="$attrs"
         v-bind="$listeners"
         #default="slotProps"
       >
         <!-- your implementation -->
-      </a11y-vue-dialog-renderless>
+      </a11y-dialog>
     </transition>
   </portal>
 </template>

--- a/docs/guide/advanced-tips.md
+++ b/docs/guide/advanced-tips.md
@@ -18,15 +18,15 @@ By these reasons i decided to deprecate this default implementation (which are j
 
 ``` vue
 <template>
-  <a11y-vue-dialog 
+  <a11y-dialog 
     :open="dialogOpen" 
     @close="dialogOpen = false"
     @show="preventScroll(true, $event)"
     @hide="preventScroll(false, $event)"
   >
-    <p>This slot content will be rendered wherever the <portal-target> with name 'a11y-vue-dialogs'
+    <p>This slot content will be rendered wherever the <portal-target> with name 'a11y-dialogs'
       is  located.</p>
-  </a11y-vue-dialog>
+  </a11y-dialog>
 </template>
 ```
 ```js

--- a/docs/guide/advanced-usage.md
+++ b/docs/guide/advanced-usage.md
@@ -19,10 +19,10 @@ Each `ref` suffixed slotProp is an object that contains a "props" and "listeners
 ```html
 <template>
   <!-- compose into you own markup, MyDialog.vue -->
-  <portal to="a11y-vue-dialogs" v-if="open">
-    <a11y-vue-dialog-renderless 
-      v-bind="$props"
-      v-bind="$listeners"
+  <portal to="a11y-dialogs" v-if="open">
+    <a11y-dialog 
+      v-bind="$attrs"
+      v-on="$listeners"
       #default="{ open, closeFn, backdropRef, dialogRef, titleRef, closeRef, focusRef }"
     >
       <div class="youclasses" 
@@ -56,22 +56,20 @@ Each `ref` suffixed slotProp is an object that contains a "props" and "listeners
           </footer>
         </div>
       </div>
-    </a11y-vue-dialog-renderless>
+    </a11y-dialog>
   </portal>
 </template>
 
 <script>
-import { A11yVueDialogRenderless } from "a11y-vue-dialog";
+import { A11yDialog } from "a11y-vue-dialog";
 import { Portal } from "portal-vue";
 
 export default {
   name: 'MyDialog',
   components: {
-    A11yVueDialogRenderless,
+    A11yDialog,
     Portal
-  },
-  extends: A11yVueDialogRenderless,
-  props: ['open', 'role']
+  }
 }
 </script>
 ```

--- a/docs/guide/basic-usage.md
+++ b/docs/guide/basic-usage.md
@@ -15,7 +15,7 @@ A renderless/headless component provides all the functionality required to build
 ```vue
 <!-- AppBaseDialog.vue -->
 <template>
-  <a11y-vue-dialog-renderless 
+  <a11y-dialog 
     v-bind="$attrs" 
     v-on="$listeners"
     v-slot:default="{ titleRef, closeRef }"
@@ -25,15 +25,15 @@ A renderless/headless component provides all the functionality required to build
     <button v-bind="closeRef.props" v-on="closeRef.listeners">
     ...
     <slot />
-  </a11y-vue-dialog>
+  </a11y-dialog>
 </template>
 
 <script>
-import { A11yVueDialogRenderless } from 'a11y-vue-dialog'
+import { A11yDialog } from 'a11y-vue-dialog'
 
 export default {
   name: 'AppBaseDialog',
-  components: { A11yVueDialogRenderless },
+  components: { A11yDialog },
   props: {
     title: {
       type: String,
@@ -69,5 +69,5 @@ import Plugin from "a11y-vue-dialog";
 
 // if you want to register globally
 Vue.use(Plugin);
-// exposes a component name <a11y-vue-dialog> by default, but configurable
+// exposes a component name <a11y-dialog> by default, but configurable
 ```

--- a/docs/guide/events.md
+++ b/docs/guide/events.md
@@ -1,12 +1,12 @@
 # Events <Badge text="in-progress" type="warn" />
 
-As any controlled component, `a11y-vue-dialog` uses the props down events up flow to communicate.
+As any controlled component, `a11y-dialog` uses the props down events up flow to communicate.
 
 
 ### `@close`
 After dialog becomes visible
 ```html
-<a11y-vue-dialog :open="dialogOpen" @close="handleClose">
+<a11y-dialog :open="dialogOpen" @close="handleClose">
  this goes to the default slots
 </a11-vue-dialog>
 ```
@@ -30,7 +30,7 @@ export default {
 ### `@show`
 When dialog becomes visible
 ```html
-<a11y-vue-dialog :open="dialogOpen" @show="onShow">
+<a11y-dialog :open="dialogOpen" @show="onShow">
 this goes to the default slots
 </a11-vue-dialog>
 ```
@@ -48,7 +48,7 @@ export default {
 ### `@hide`
 When dialog becomes visible
 ```html
-<a11y-vue-dialog :open="dialogOpen" @hide="onHide">
+<a11y-dialog :open="dialogOpen" @hide="onHide">
 this goes to the default slots
 </a11-vue-dialog>
 ```

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -97,8 +97,8 @@
 
 
     <!-- render at end of root -->
-    <portal-target name="a11y-vue-dialogs" multiple />
-    <div id="a11y-vue-dialogs" />
+    <portal-target name="a11y-dialogs" multiple />
+    <div id="a11y-dialogs" />
   </div>
 </template>
 
@@ -114,7 +114,7 @@ export default {
   components: {
     DialogExample,
     PortalTarget,
-    // A11yVueDialogRenderless
+    // A11yDialog
   },
   data: () => ({
     last: false,

--- a/playground/src/components/DialogExample.vue
+++ b/playground/src/components/DialogExample.vue
@@ -4,7 +4,7 @@
     :to="!useSimplePortal && 'a11y-vue-dialogs'"
   >
     <transition name="fade" mode="out-in" appear v-if="open">
-      <a11y-vue-dialog-renderless
+      <a11y-dialog
         v-bind="$props"
         v-on="$listeners"
         #default="{ open, backdropRef, dialogRef, titleRef, closeRef, focusRef }"
@@ -34,24 +34,24 @@
             </section>
           </div>
         </div>
-      </a11y-vue-dialog-renderless>
+      </a11y-dialog>
     </transition>
   </component>
 </template>
 
 <script>
-import { A11yVueDialogRenderless } from '../../../src/index'
+import { A11yDialog } from '../../../src/index'
 import { Portal } from "portal-vue";
 import { Portal as SimplePortal } from "@linusborg/vue-simple-portal";
 
 export default {
   name: 'DialogExample',
   components: {
-    A11yVueDialogRenderless,
+    A11yDialog,
     Portal,
     SimplePortal
   },
-  extends: {A11yVueDialogRenderless},
+  extends: {A11yDialog},
   props: ['open', 'role', 'useSimplePortal'],
   data: () => ({
     disablePortal: false,

--- a/src/A11yDialog.vue
+++ b/src/A11yDialog.vue
@@ -22,7 +22,7 @@ const getInitialState = () => ({
 export const VALID_ROLES = ["dialog", "alertdialog"];
 
 export default {
-  name: "a11y-vue-dialog-renderless",
+  name: "a11y-dialog",
   props: {
     /**
      * @desc control's dialog visibility
@@ -158,7 +158,7 @@ export default {
      * @returns {Boolean} performs checks for other ref dependend methods
      */
     getDOMRefs() {
-      this.dialogRoot = document.querySelector(`[data-id="a11y-vue-dialog-${this._uid}"]`);
+      this.dialogRoot = document.querySelector(`[data-id="a11y-dialog-${this._uid}"]`);
 
       if (this.dialogRoot) {
         this.dialogEl = this.dialogRoot.querySelector('[data-ref="dialog"]');
@@ -315,7 +315,7 @@ export default {
    * called. Needs investigation
    */
   created() {
-    this.id = `a11y-vue-dialog-${this._uid}`
+    this.id = `a11y-dialog-${this._uid}`
   },
 
   beforeDestroy() {

--- a/src/__tests__/A11yDialog.spec.js
+++ b/src/__tests__/A11yDialog.spec.js
@@ -1,5 +1,5 @@
 import { mount } from "@vue/test-utils";
-import A11yVueDialogRenderless from "../A11yVueDialogRenderless.vue";
+import A11yDialog from "../A11yDialog.vue";
 
 /**
  * Gotachas:
@@ -8,10 +8,10 @@ import A11yVueDialogRenderless from "../A11yVueDialogRenderless.vue";
  *  are visible, till we refactor this test suite
  *    @see https://github.com/jsdom/jsdom/issues/1048
  */
-describe("A11yVueDialogRenderless", () => {
+describe("A11yDialog", () => {
   // [1]
   const mockIsVisible = jest.fn().mockReturnValue(true)
-  
+
   const methodsMock = {
     close: jest.fn(),
     handleKeyboard: jest.fn(),
@@ -25,10 +25,10 @@ describe("A11yVueDialogRenderless", () => {
    * 🤦‍♂️
    * @todo // [1]
    */
-  const MockedA11yVueDialogRenderless = {
-    ...A11yVueDialogRenderless,
+  const MockedA11yDialog = {
+    ...A11yDialog,
     methods: {
-      ...A11yVueDialogRenderless.methods,
+      ...A11yDialog.methods,
       _isVisible: mockIsVisible
     }
   }
@@ -38,7 +38,7 @@ describe("A11yVueDialogRenderless", () => {
    */
   const WrapperComp = {
     components: {
-      MockedA11yVueDialogRenderless
+      MockedA11yDialog
     },
     props: {
       showFocusRef: {
@@ -55,12 +55,12 @@ describe("A11yVueDialogRenderless", () => {
       isOpen: false,
     }),
     template: `
-      <MockedA11yVueDialogRenderless
+      <MockedA11yDialog
         :open="isOpen"
         @close="$emit('close')"
         #default="{ open, backdropRef, dialogRef, titleRef, closeRef, focusRef }"
       >
-        <portal to="a11y-vue-dialogs" v-if="open">
+        <portal to="a11y-dialogs" v-if="open">
           <div
             class="mock-dialog"
             v-bind="backdropRef.props"
@@ -112,7 +112,7 @@ describe("A11yVueDialogRenderless", () => {
             </div>
           </div>
         </portal>
-      </MockedA11yVueDialogRenderless>
+      </MockedA11yDialog>
     `
   };
 
@@ -124,7 +124,7 @@ describe("A11yVueDialogRenderless", () => {
         ...options.stubs
       },
       ...options
-    }).find(A11yVueDialogRenderless)
+    }).find(A11yDialog)
   }
 
   const wrapper = mountWithOptions()
@@ -138,7 +138,7 @@ describe("A11yVueDialogRenderless", () => {
   // beforeEach(() => {
   //   spyError.mockReset()
   //   spyWarn.mockReset()
-  // }) 
+  // })
 
   const event = { stopPropagation: jest.fn() }
 
@@ -152,7 +152,7 @@ describe("A11yVueDialogRenderless", () => {
   // sanity check
   it("is a Vue instance", () => {
     expect(wrapper.isVueInstance()).toBeTruthy();
-    expect(wrapper.is(A11yVueDialogRenderless)).toBeTruthy();
+    expect(wrapper.is(A11yDialog)).toBeTruthy();
   });
 
   describe('props', () => {
@@ -178,7 +178,7 @@ describe("A11yVueDialogRenderless", () => {
       it('should attach correct binding props to bound element', () => {
         expect(backdropRef.attributes('data-ref')).toBe('backdrop')
         expect(backdropRef.attributes('tabindex')).toBe('-1')
-        expect(backdropRef.attributes('data-id')).toContain(`a11y-vue-dialog-`)
+        expect(backdropRef.attributes('data-id')).toContain(`a11y-dialog-`)
       })
 
       it('should attach correct binding listeners to bound element', async () => {
@@ -197,14 +197,14 @@ describe("A11yVueDialogRenderless", () => {
         const dialogRef = _wrapper.find('.mock-dialog__inner')
         expect(dialogRef.attributes('data-ref')).toBe('dialog')
         expect(dialogRef.attributes('role')).toBe('dialog')
-        expect(dialogRef.attributes('aria-labelledby')).toContain(`a11y-vue-dialog-`)
+        expect(dialogRef.attributes('aria-labelledby')).toContain(`a11y-dialog-`)
       })
 
       /**
        * @todo [1] - I must be doing something wrong, but using setMethods() will make
        * subsequent tests that depend on emit (not mocked methods) fail. I don't
        * know why since we're mounting a component per test. I have no f*ing clue
-       * 
+       *
        * also i can't just assert method calling not matter what i do. can't figure
        * out why right now and i've already lost too much time on this. It is working
        * just add a console.log('') to handleKeyboard and close() and jest will log
@@ -212,20 +212,20 @@ describe("A11yVueDialogRenderless", () => {
        */
       it('should attach correct binding listeners to bound element', async () => {
         const test = jest.fn(event)
-        const _wrapper = mountWithOptions({ 
+        const _wrapper = mountWithOptions({
           methods: {
             handleKeyboard: test
           },
           data: () => ({ isOpen: true }) })
-          
+
         await _wrapper.vm.$nextTick()
 
         const dialogRef = _wrapper.find('.mock-dialog__inner')
-        
+
         dialogRef.trigger('click', event)
         // dialogRef.trigger('keydown.esc', another)
         // dialogRef.trigger('keydown.tab', event)
-        
+
         await _wrapper.vm.$nextTick()
 
         expect(event.stopPropagation).toBeCalledTimes(1);
@@ -281,14 +281,14 @@ describe("A11yVueDialogRenderless", () => {
         const _wrapper = mountWithOptions({ data: () => ({ isOpen: true }) })
 
         await _wrapper.vm.$nextTick()
-        
+
         expect(_wrapper.emitted().show).toBeTruthy()
         expect(_wrapper.emitted().show[0][0]).toBe(false) // hasSiblings
-        
+
         _wrapper.setProps({ open: false })
-        
+
         await _wrapper.vm.$nextTick()
-        
+
         expect(_wrapper.emitted().hide).toBeTruthy()
         expect(_wrapper.emitted().hide[0][0]).toBe(false) // hasSiblings
       })
@@ -319,19 +319,19 @@ describe("A11yVueDialogRenderless", () => {
       * @todo for cases where backdrop is root and wraps dialogRef (content)
       * edge case when someone, for example, starts selecting text inside
       * dialogRef and drags selection to outside and relases mouse click (mouseup)
-      * 
+      *
       * 🆘 I have no clue how to write a test for this
       *
-      * @see A11yVueDialogRenderless#captureMouseUp 
+      * @see A11yDialog#captureMouseUp
       */
-      it('should stop backdropRef click event if mouseup on backdropRef is preceded from a mousedown with a different origin', async () => {      
-        const container = mountWithOptions({ 
+      it('should stop backdropRef click event if mouseup on backdropRef is preceded from a mousedown with a different origin', async () => {
+        const container = mountWithOptions({
           data: () => ({ isOpen: true })
         })
 
         const backdropRefIsRoot = container.find('[data-ref="backdrop"]')
         const dialogRef = container.find('[data-ref="dialog"]')
-        
+
         expect(container.vm.mouseDownOrigin).toBeNull();
         dialogRef.trigger('mousedown')
 
@@ -344,8 +344,8 @@ describe("A11yVueDialogRenderless", () => {
         // since mouse
         expect(container.emitted().close).toBeUndefined()
         // this is what's actually happen but can't mock
-        //expect(container.vm.captureMouseUp).toHaveBeenCalled()        
-        //expect(container.vm.mouseDownOrigin).toBeNull()        
+        //expect(container.vm.captureMouseUp).toHaveBeenCalled()
+        //expect(container.vm.mouseDownOrigin).toBeNull()
       })
     })
   })

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
-import A11yVueDialogRenderless from "./A11yVueDialogRenderless.vue";
+import A11yDialog from "./A11yDialog.vue";
 
 const DEFAULTS = {
-  componentName: "a11y-vue-dialog",
+  componentName: "a11y-dialog",
 }
 
 var Plugin = {
@@ -19,16 +19,16 @@ var Plugin = {
     // is there a better way of doing this
     // (extend default prop value on component registration)*
     if( options.props) {
-      Object.keys(A11yVueDialogRenderless.props).map(propName => {
+      Object.keys(A11yDialog.props).map(propName => {
         if(options.props[propName]) {
-          A11yVueDialogRenderless.props[propName]['default'] = options.props[propName];
+          A11yDialog.props[propName]['default'] = options.props[propName];
         }
       });
     }
 
-    Vue.component(this.componentName, A11yVueDialogRenderless)
+    Vue.component(this.componentName, A11yDialog)
   }
 }
 
-export { A11yVueDialogRenderless };
+export { A11yDialog };
 export default Plugin;


### PR DESCRIPTION
- since we're are now fully assumed as a renderless / headless component, there's no need to add the suffix. People using it already know.
- The original name of the component was to match the name of npm package, but it makes it excessively verbose; this is a vue package, to be used in vue, no need for that  "-vue-" middle name

BREAKING-CHANGE:
- up this will break your apps folks! Sry about that, but that's why this is a 0.x.x version!